### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 bumpversion
-fuzzywuzzy
 gmusicapi
 kafka-python
 oauth2client
 pymaybe
-python-Levenshtein
+rapidfuzz
 spotipy

--- a/wrappers/spotify/search_wrapper.py
+++ b/wrappers/spotify/search_wrapper.py
@@ -1,5 +1,5 @@
 from exceptions.spotify.search_exceptions import NoMatchException
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 from meta.structures.track import GpmTrack, SpotifyTrack
 from spotipy import Spotify
 from typing import Tuple


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy